### PR TITLE
Profile posted/claimed items

### DIFF
--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -38,7 +38,7 @@ const MainPage = ({ navigation, route }) => {
   const resetSearch = () => {
     //called by "x" button displayed when search bar is open.
     handleSearch() //what was originally called by that button
-    getItems //reset the search results.
+    getItems() //reset the search results.
   }
 
   /*Function/useEffect used to give feedback to the user after they (successfully, determined by the conditional below) add an item 
@@ -51,9 +51,17 @@ const MainPage = ({ navigation, route }) => {
 
   useEffect(() => {
       //load data
-      getItems();
-      //setIsLoading(false);
-      //setData(generatePlaceholderData(5)); // Generate 10 placeholder posts
+      if(prevRoute === "post") {
+        //if coming from profile page looking for user.postUser (that user's posts)
+        getItemsPosted();
+      } else if (prevRoute === "claim") {
+        //if coming from profile page looking for user.claimUser (that user's claimed items)
+        getItemsClaimed();
+      } else {
+        getItems();
+        //setIsLoading(false);
+        //setData(generatePlaceholderData(5)); // Generate 10 placeholder posts
+      }
   }, []);
 
   const getItems = async () => {
@@ -62,7 +70,34 @@ const MainPage = ({ navigation, route }) => {
       const json = await response.json();
       setData(json);
     } catch (error) {
-      console.error(error);
+      //console.error(error);
+      setData([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getItemsPosted = async () => {
+    try {
+    const response = await fetch('https://calvinfinds.azurewebsites.net/items/post/Edom@gmail.com'); //hardcoded for demo
+      const json = await response.json();
+      setData(json);
+    } catch (error) {
+      //console.error(error);
+      setData([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getItemsClaimed = async () => {
+    try {
+    const response = await fetch('https://calvinfinds.azurewebsites.net/items/claim/Edom@gmail.com'); //hardcoded for demo
+      const json = await response.json();
+      setData(json);
+    } catch (error) {
+      //console.error(error);
+      setData([]);
     } finally {
       setIsLoading(false);
     }

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -20,20 +20,6 @@ const MainPage = ({ navigation, route }) => {
     setSearchActive(!searchActive);  // Toggle the searchActive state
   };
 
-  const searchItem = async (text) => {
-    setSearchedItem(text)
-    try {
-      const response = await fetch('https://calvinfinds.azurewebsites.net/items/' + text);
-        const json = await response.json();
-        setData(json);
-      } catch (error) {
-        //console.error(error);
-        setData([]);
-      } finally {
-        setIsLoading(false);
-      };
-  };
-
   //clears results (resets search to show all results to user) when "x" is pressed. CHANGE: may want to check whether searchedItem='' (is the search bar empty?)
   const resetSearch = () => {
     //called by "x" button displayed when search bar is open.
@@ -52,7 +38,7 @@ const MainPage = ({ navigation, route }) => {
   useEffect(() => {
       //load data
       if(prevRoute === "post") {
-        //if coming from profile page looking for user.postUser (that user's posts)
+        //if coming from profile page looking for user.postUser (that user's posts) 
         getItemsPosted();
       } else if (prevRoute === "claim") {
         //if coming from profile page looking for user.claimUser (that user's claimed items)
@@ -62,7 +48,7 @@ const MainPage = ({ navigation, route }) => {
         //setIsLoading(false);
         //setData(generatePlaceholderData(5)); // Generate 10 placeholder posts
       }
-  }, []);
+  }, [prevRoute]);
 
   const getItems = async () => {
     try {
@@ -75,6 +61,20 @@ const MainPage = ({ navigation, route }) => {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const searchItem = async (text) => {
+    setSearchedItem(text)
+    try {
+      const response = await fetch('https://calvinfinds.azurewebsites.net/items/' + text);
+        const json = await response.json();
+        setData(json);
+      } catch (error) {
+        //console.error(error);
+        setData([]);
+      } finally {
+        setIsLoading(false);
+      };
   };
 
   const getItemsPosted = async () => {

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -66,7 +66,7 @@ const MainPage = ({ navigation, route }) => {
   const searchItem = async (text) => {
     setSearchedItem(text)
     try {
-      const response = await fetch('https://calvinfinds.azurewebsites.net/items/' + text);
+      const response = await fetch('https://calvinfinds.azurewebsites.net/items/search/' + text);
         const json = await response.json();
         setData(json);
       } catch (error) {

--- a/screens/loginscreen/profile.js
+++ b/screens/loginscreen/profile.js
@@ -13,12 +13,12 @@ const Profile = ({  }) => {
       <View style={styles.flexContainer}>
 
         {/* this Button should lead to item page for user */}
-        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: 'post' })}>
+        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: "post" })}>
           <Text style={styles.tertiaryButtonTitle}>10</Text>
           <Text style={styles.tertiaryButtonText}>Posted</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: 'claim' })}>
+        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: "claim" })}>
           <Text style={styles.tertiaryButtonTitle}>0</Text>
           <Text style={styles.tertiaryButtonText}>Claimed</Text>
         </TouchableOpacity> 

--- a/screens/loginscreen/profile.js
+++ b/screens/loginscreen/profile.js
@@ -8,18 +8,18 @@ const Profile = ({  }) => {
   return (
     <View style={styles.container}>
       <Image source={require('../../assets/user.png')} style={profileStyles.userIconStyle} />
-      <Text style={styles.userName}>User Name</Text>
-      <Text style={styles.userEmail}>ab12@calvin.edu</Text>
+      <Text style={styles.userName}>Edom</Text>
+      <Text style={styles.userEmail}>Edom@gmail.com</Text>
       <View style={styles.flexContainer}>
 
         {/* this Button should lead to item page for user */}
-        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.goBack()}> 
-          <Text style={styles.tertiaryButtonTitle}>0</Text>
+        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: 'post' })}>
+          <Text style={styles.tertiaryButtonTitle}>10</Text>
           <Text style={styles.tertiaryButtonText}>Posted</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.goBack()}>
-          <Text style={styles.tertiaryButtonTitle}>13</Text>
+        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: 'claim' })}>
+          <Text style={styles.tertiaryButtonTitle}>0</Text>
           <Text style={styles.tertiaryButtonText}>Claimed</Text>
         </TouchableOpacity> 
 


### PR DESCRIPTION
Adds a route from profile page buttons (posted/claimed [used to be "archived"]) -> main page. Shows only what the user has posted/claimed, respectively, on the main page. 

Future changes: remove search bar and add button [replace add button with "back" button] from this version of the page (hide them when prevRoute == "post"/"claim") or reuse the search bar and send a different query to the dbms (only search within this subset of results).
