### PR TITLE
made text limit 35 so comment doesn't go off screen

### DIFF
--- a/screens/loginscreen/details.js
+++ b/screens/loginscreen/details.js
@@ -24,6 +24,9 @@ function Details({ navigation, route }) {
   const [profileIcon, setProfileIcon] = useState('');
   const [userLoading, setUserLoading] = useState(true);
 
+  // used for limit on comments so no words go off screen
+  const [isMaxLengthError, setMaxLengthError] = useState(false);
+
 
   //value stored in dropdown (see categories item label/value)
   const [value, setValue] = useState(null);
@@ -101,9 +104,8 @@ function Details({ navigation, route }) {
       .catch(error => {
         console.error(error);
     });
-
     // Clear the comment in the TextInput
-    setComment('');
+    setComment(''); 
   };
 
   const handleDelete = () => {
@@ -257,6 +259,7 @@ function Details({ navigation, route }) {
                 autoCapitalize="none"
                 value={comment}
                 onChangeText={(text) => setComment(text)} // Update the comment state
+                maxLength={35} // if over 35 then I can't see the rest of comment because it goes off screen.
               />
               <TouchableOpacity style={styles.sendButton} onPress={handleSendPress}>
                 <Image source={require('../../assets/send.png')} style={styles.sendIconStyle} />

--- a/screens/loginscreen/details.js
+++ b/screens/loginscreen/details.js
@@ -24,10 +24,6 @@ function Details({ navigation, route }) {
   const [profileIcon, setProfileIcon] = useState('');
   const [userLoading, setUserLoading] = useState(true);
 
-  // used for limit on comments so no words go off screen
-  const [isMaxLengthError, setMaxLengthError] = useState(false);
-
-
   //value stored in dropdown (see categories item label/value)
   const [value, setValue] = useState(null);
   //handles user clicking on dropdown. Opens/closes the dropdown menu.


### PR DESCRIPTION
I noticed a long comment goes off-screen, so I added a limit to the comment text box at 35 characters because that is the limit of characters you can see on screen at one given time. This is a good change to talk about in the presentation. I tried to put in an error if text is to long but later found out that it was not necessary and too much work.