### PR TITLE
Fix/ Image Quality

### DIFF
--- a/screens/addpage/addpage.js
+++ b/screens/addpage/addpage.js
@@ -86,7 +86,7 @@ function AddPage({ route }) {
   const pickImageAsync = async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
       allowsEditing: true,
-      quality: 1,
+      quality: .25,
       base64: true, // enables the return of binary image data 
     });
 
@@ -128,7 +128,7 @@ function AddPage({ route }) {
   const takePhoto = async () => {
     const result = await ImagePicker.launchCameraAsync({
       allowsEditing: true,
-      quality: 1,
+      quality: .25,
       base64: true, // enables the return of binary image data 
     });
 


### PR DESCRIPTION
Changed item image quality from 1 to .25. For more information, see the "quality" prop for expo-image-picker (https://docs.expo.dev/versions/latest/sdk/imagepicker/)