### PR TITLE
Feature/search filters

### DIFF
--- a/screens/loginscreen/details.js
+++ b/screens/loginscreen/details.js
@@ -115,7 +115,7 @@ function Details({ navigation, route }) {
       .catch(error => {
         console.error(error);
     });
-    navigation.navigate('MainPage', { prevRoute: 'archive' }); // change so that the user can get a message on main page
+    navigation.navigate('MainPage', { prevRoute: 'delete' }); // so that the user can get a message on main page
   };
 
   const deleteBackButton = () => {

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -63,11 +63,12 @@ const MainPage = ({ navigation, route }) => {
     setSearchActive(!searchActive);  // Toggle the searchActive state
   };
 
-  // clears results (resets search to show all results to user) when "x" is pressed. CHANGE: may want to check whether searchedItem='' (is the search bar empty?)
+  // clears results (resets search to show all results to user) when "x" is pressed.
   const resetSearch = () => {
     // called by "x" button displayed when search bar is open.
-    handleSearch() // what was originally called by that button
-    getItems() // reset the search results.
+    handleSearch() // collapse search bar
+    // reset the search results. Based on whether you are looking through archived, posted, or all items.
+    fetchData()
   }
 
   /* Function/useEffect used to give feedback to the user after they (successfully, determined by the conditional below) add an item 
@@ -119,7 +120,7 @@ const MainPage = ({ navigation, route }) => {
 
   const getItems = async () => {
     try {
-    const response = await fetch(`https://calvinfinds.azurewebsites.net/items`);// /${lostOrFoundFilter}`); was used for remote filter
+    const response = await fetch(`https://calvinfinds.azurewebsites.net/items`);
       const json = await response.json();
       setData(json);
     } catch (error) {
@@ -136,7 +137,7 @@ const MainPage = ({ navigation, route }) => {
   const searchItem = async (text) => {
     setSearchedItem(text)
     try {
-      const response = await fetch(`https://calvinfinds.azurewebsites.net/items/search/${text}/${lostOrFoundFilter}/${userID}/${prevRoute}`);
+      const response = await fetch(`https://calvinfinds.azurewebsites.net/items/search/${text}/${userID}/${prevRoute}`);
         const json = await response.json();
         setData(json);
       } catch (error) {

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -242,10 +242,6 @@ const MainPage = ({ navigation, route }) => {
                         <Text style={styles.date}>
                             {item.dateposted}
                         </Text>
-                        {/* comments should be only visible in item page */}
-                        {/* <Text style={styles.comments}>
-                            Comments
-                        </Text> */}
                     </View>
                 </View>
                 <Image
@@ -320,7 +316,6 @@ const MainPage = ({ navigation, route }) => {
         {/* Uses a keyboard avoiding view which ensures the keyboard does not cover the items on screen */}
 
           <View style={styles.bottomRow}>
-            {/* {(prevRoute !== 'post' && prevRoute !== 'archived') && ( */}
             <View style={styles.toggleContainer}>
               <TouchableOpacity 
                 style={lostOrFoundFilter === 'Lost' ? styles.activeButton : styles.inactiveButton} 
@@ -340,7 +335,6 @@ const MainPage = ({ navigation, route }) => {
                 </View>
               </TouchableOpacity>
             </View>
-            {/* )} */}
             
             <TouchableOpacity onPress={() => {
               // send information to the main (current) page to "reset" the pop up.

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -120,7 +120,7 @@ const MainPage = ({ navigation, route }) => {
 
   const getItems = async () => {
     try {
-    const response = await fetch(`https://calvinfinds.azurewebsites.net/items`);
+    const response = await fetch('https://calvinfinds.azurewebsites.net/items');
       const json = await response.json();
       setData(json);
     } catch (error) {
@@ -220,6 +220,7 @@ const MainPage = ({ navigation, route }) => {
     } 
 
   const renderItem = ({ item }) => {
+    // Filter for lost vs found. Only load the item if it matches the filter switch's current state.
     if (item.lostfound === lostOrFoundFilter.toLowerCase()) {
       return (
         <TouchableOpacity onPress={() => handleDetailsOpen(item)}>

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -75,7 +75,7 @@ const MainPage = ({ navigation, route }) => {
     Right now, that just means that the user made an item listing at the "addPage" screen. */
   useEffect(() => {
     if (prevRoute === "AddPage") alert("Your item has been posted!"); 
-    if (prevRoute === 'archive') alert('Your item has been archived and will no longer appear in search results.')
+    if (prevRoute === 'delete') alert('Your item has been archived and will no longer appear in search results.');
   }, [prevRoute]); // If prevRoute changes (which it does when navigating to this page), run the function.
 
 
@@ -90,8 +90,8 @@ const MainPage = ({ navigation, route }) => {
           alert("No posted items found.");
           navigation.navigate('Profile');
         }
-      } else if (prevRoute === "claim") {
-        // If coming from the profile page looking for user.claimUser (that user's claimed items)
+      } else if (prevRoute === "archived") {
+        // If coming from the profile page looking for user.postUser (that user's archived items)
         const archivedData = await getItemsArchived();
         // Handle empty array only when the data retrieval is complete
         if (archivedData.length === 0) {
@@ -119,7 +119,7 @@ const MainPage = ({ navigation, route }) => {
 
   const getItems = async () => {
     try {
-    const response = await fetch('https://calvinfinds.azurewebsites.net/items');
+    const response = await fetch(`https://calvinfinds.azurewebsites.net/items`);// /${lostOrFoundFilter}`); was used for remote filter
       const json = await response.json();
       setData(json);
     } catch (error) {
@@ -218,41 +218,45 @@ const MainPage = ({ navigation, route }) => {
         navigation.navigate('Details', { itemData: selectedItem }) // pass json data of a given item as itemData
     } 
 
-  const renderItem = ({ item }) => (
-    <TouchableOpacity onPress={() => handleDetailsOpen(item)}>
-      <View style={styles.itemContainer}>
-        <View style={styles.postContainer}>
-            <View style={styles.row}>  
-                <View style={styles.nameDescription}>
-                    <Text style={styles.itemName}>
-                        {item.title}
-                    </Text>
-                    <Text style={styles.description}>
-                        {item.description}
-                    </Text>
-                </View>
+  const renderItem = ({ item }) => {
+    if (item.lostfound === lostOrFoundFilter.toLowerCase()) {
+      return (
+        <TouchableOpacity onPress={() => handleDetailsOpen(item)}>
+          <View style={styles.itemContainer}>
+            <View style={styles.postContainer}>
+                <View style={styles.row}>  
+                    <View style={styles.nameDescription}>
+                        <Text style={styles.itemName}>
+                            {item.title}
+                        </Text>
+                        <Text style={styles.description}>
+                            {item.description}
+                        </Text>
+                    </View>
 
-                <View style={styles.userDate}>
-                    <Text style={styles.username}> 
-                        {item.name}
-                    </Text>
-                    <Text style={styles.date}>
-                        {item.dateposted}
-                    </Text>
-                    {/* comments should be only visible in item page */}
-                    {/* <Text style={styles.comments}>
-                        Comments
-                    </Text> */}
+                    <View style={styles.userDate}>
+                        <Text style={styles.username}> 
+                            {item.name}
+                        </Text>
+                        <Text style={styles.date}>
+                            {item.dateposted}
+                        </Text>
+                        {/* comments should be only visible in item page */}
+                        {/* <Text style={styles.comments}>
+                            Comments
+                        </Text> */}
+                    </View>
                 </View>
+                <Image
+                    source={item.itemimage == null ? require('../../assets/placeholder.jpg') : demoImageGetter.getImage(item.itemimage)} //  Placeholder image for post. item.itemimage is a uri for now
+                    style={styles.postImage}
+                />
             </View>
-            <Image
-                source={item.itemimage == null ? require('../../assets/placeholder.jpg') : demoImageGetter.getImage(item.itemimage)} //  Placeholder image for post. item.itemimage is a uri for now
-                style={styles.postImage}
-            />
-        </View>
-      </View>
-    </TouchableOpacity>
-  );
+          </View>
+        </TouchableOpacity>
+      )}
+    return null; // else
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -315,7 +319,7 @@ const MainPage = ({ navigation, route }) => {
         {/* Uses a keyboard avoiding view which ensures the keyboard does not cover the items on screen */}
 
           <View style={styles.bottomRow}>
-
+            {/* {(prevRoute !== 'post' && prevRoute !== 'archived') && ( */}
             <View style={styles.toggleContainer}>
               <TouchableOpacity 
                 style={lostOrFoundFilter === 'Lost' ? styles.activeButton : styles.inactiveButton} 
@@ -335,7 +339,7 @@ const MainPage = ({ navigation, route }) => {
                 </View>
               </TouchableOpacity>
             </View>
-
+            {/* )} */}
             
             <TouchableOpacity onPress={() => {
               // send information to the main (current) page to "reset" the pop up.

--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -136,7 +136,7 @@ const MainPage = ({ navigation, route }) => {
   const searchItem = async (text) => {
     setSearchedItem(text)
     try {
-      const response = await fetch(`https://calvinfinds.azurewebsites.net/items/search/${text}`);
+      const response = await fetch(`https://calvinfinds.azurewebsites.net/items/search/${text}/${lostOrFoundFilter}/${userID}/${prevRoute}`);
         const json = await response.json();
         setData(json);
       } catch (error) {

--- a/screens/loginscreen/profile.js
+++ b/screens/loginscreen/profile.js
@@ -173,7 +173,7 @@ try {
           <Text style={styles.tertiaryButtonText}>Posted</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: "claim", key: Math.random().toString()})}>
+        <TouchableOpacity style={styles.tertiaryButton} onPress={() => navigation.navigate('MainPage', { prevRoute: "archived", key: Math.random().toString()})}>
           <Text style={styles.tertiaryButtonTitle}>{archivedCount}</Text>
           <Text style={styles.tertiaryButtonText}>Archived</Text>
         </TouchableOpacity> 


### PR DESCRIPTION
Client-side changes to filter for lost/found items (handled in client, in the "renderItem" function).

Also sends information to the service that makes searching through archived/posted items possible. The "x" button in the search bar also resets to all archived/posted items when searching through archived/posted items (profile -> mainpage).

One issue that needs to be addressed: since the 'x' button does not reset the entire mainpage when on the archived/posted version of the mainpage, there is no easy way to get back to the mainpage listing of all database items.

If what I wrote in this description was incoherent, don't worry too much about it. These notes are for me for things I plan to fix within the next day.