### PR TITLE
Feature: Back Button on Main Page when Viewing Archived/Posted Items

### DIFF
--- a/screens/loginscreen/mainpage.js
+++ b/screens/loginscreen/mainpage.js
@@ -338,6 +338,22 @@ const MainPage = ({ navigation, route }) => {
                 <Image source={require('../../assets/add.png')} style={styles.addIconStyle} />
             </TouchableOpacity>
           )}
+          {(prevRoute === "post" || prevRoute === "archived") && (
+            <TouchableOpacity style={styles.addButton}
+                onPress={() => {
+                    // send information to the main (current) page to "reset" the page.
+                    // changes from the posted/archived view to the default (all posts) view
+                    navigation.navigate({
+                        name: 'MainPage',
+                        params: { prevRoute: 'reset'},
+                        merge: true,
+                    }),
+                    // navigate to the profile page (where the user will actually end up)
+                    navigation.navigate('Profile')
+                }}>
+                <Image source={require('../../assets/send.png')} style={styles.addIconStyle} />
+            </TouchableOpacity>
+          )}
           {/* search button */}
           {searchActive && (
             <TouchableOpacity style={styles.searchButton} onPress={handleSearch}>


### PR DESCRIPTION
extra button for returning to profile page from mainpage when coming from profile->archived/posted items. Returns the user to the profile page.

This navigation works with a coded-in button, but not with react navigation (built-in phone gestures/back button in navigation bar)

The image for the back button needs to be updated. It is currently the same button as the one for posting comments (as a placeholder)